### PR TITLE
Clarification of make plugin help text

### DIFF
--- a/snapcraft/plugins/make.py
+++ b/snapcraft/plugins/make.py
@@ -19,6 +19,8 @@
 Make based projects are projects that have a Makefile that drives the
 build.
 
+This plugin always runs 'make' followed by 'make install'.
+
 This plugin uses the common plugin keywords as well as those for "sources".
 For more information check the 'plugins' topic for the former and the
 'sources' topic for the latter.


### PR DESCRIPTION
Just helped debug a makefile based project that failed because 'install' was the default target, and running 'make && make install' broke the build. This clarification would've made it easier to understand what the plugin was actually doing.